### PR TITLE
Implements ProcessEventWatcher class

### DIFF
--- a/source/Loom.Messaging.Abstraction/Processes/ProcessEventWatcher.cs
+++ b/source/Loom.Messaging.Abstraction/Processes/ProcessEventWatcher.cs
@@ -1,0 +1,22 @@
+﻿namespace Loom.Messaging.Processes
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class ProcessEventWatcher : IMessageHandler
+    {
+        private readonly IProcessEventCollector _collecotr;
+
+        public ProcessEventWatcher(IProcessEventCollector collector)
+        {
+            _collecotr = collector;
+        }
+
+        public bool CanHandle(Message message) => true;
+
+        public Task Handle(Message message)
+        {
+            return _collecotr.Collect(message, CancellationToken.None);
+        }
+    }
+}

--- a/source/Loom.Tests/Messaging/Processes/ProcessEventWatcher_specs.cs
+++ b/source/Loom.Tests/Messaging/Processes/ProcessEventWatcher_specs.cs
@@ -1,0 +1,65 @@
+﻿namespace Loom.Messaging.Processes
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Loom.Messaging;
+    using Loom.Testing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ProcessEventWatcher_specs
+    {
+        [TestMethod]
+        public void sut_implements_IMessageHandler()
+        {
+            typeof(ProcessEventWatcher).Should().Implement<IMessageHandler>();
+        }
+
+        [TestMethod, AutoData]
+        public void CanHandle_true_for_Message(
+            IProcessEventCollector dummy,
+            Message message)
+        {
+            // Arrange
+            var sut = new ProcessEventWatcher(dummy);
+
+            // Act
+            bool actual = sut.CanHandle(message);
+
+            // Assert
+            actual.Should().BeTrue();
+        }
+
+        [TestMethod, AutoData]
+        public async Task Handle_collects_message_correctly(
+            Spy collector,
+            Message message)
+        {
+            // Arrange
+            var sut = new ProcessEventWatcher(collector);
+
+            // Act
+            await sut.Handle(message);
+
+            // Assert
+            List<Message> actual = collector.Messages;
+            actual.Should().HaveCount(1);
+            actual[0].Should().BeEquivalentTo(message);
+        }
+
+        public class Spy : IProcessEventCollector
+        {
+            public List<Message> Messages { get; } = new List<Message>();
+
+            public Task Collect(
+                Message message,
+                CancellationToken cancellationToken)
+            {
+                Messages.Add(message);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
ProcessEventWatcher uses IProcessEventCollector to store all messages.

work items: [AB#40](https://dev.azure.com/tachycardia/f288cb04-fc97-4692-857f-b997e8543abb/_workitems/edit/40)