### PR TITLE
Rename CosmosProcessEventCache class

### DIFF
--- a/source/Loom.Messaging.Azure/Processes/Azure/CosmosProcessMessageCache.cs
+++ b/source/Loom.Messaging.Azure/Processes/Azure/CosmosProcessMessageCache.cs
@@ -1,4 +1,4 @@
-﻿namespace Loom.Messaging.Azure
+﻿namespace Loom.Messaging.Processes.Azure
 {
     using System;
     using System.Collections.Generic;
@@ -7,19 +7,20 @@
     using System.Threading.Tasks;
     using Loom.Json;
     using Loom.Messaging;
+    using Loom.Messaging.Azure;
     using Loom.Messaging.Processes;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.Azure.Cosmos.Linq;
 
-    public class CosmosProcessEventCache
+    public class CosmosProcessMessageCache
         : IProcessEventReader, IProcessEventCollector
     {
         private readonly Container _container;
         private readonly IJsonProcessor _jsonProcessor;
         private readonly TypeResolver _typeResolver;
 
-        public CosmosProcessEventCache(
+        public CosmosProcessMessageCache(
             string connectionString,
             string databaseId,
             string containerId,

--- a/source/Loom.Tests/Messaging/Processes/Azure/CosmosProcessMessageCache_specs.cs
+++ b/source/Loom.Tests/Messaging/Processes/Azure/CosmosProcessMessageCache_specs.cs
@@ -1,4 +1,4 @@
-﻿namespace Loom.Messaging.Azure
+﻿namespace Loom.Messaging.Processes.Azure
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -6,14 +6,13 @@
     using System.Threading.Tasks;
     using FluentAssertions;
     using Loom.Json;
-    using Loom.Messaging.Processes;
     using Loom.Testing;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
-    public class CosmosProcessEventCache_specs
+    public class CosmosProcessMessageCache_specs
     {
         private const string ConnectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
         private const string DatabaseId = "UnitTestingDatabase";
@@ -62,13 +61,13 @@
         [TestMethod]
         public void sut_implements_IProcessEventReader()
         {
-            typeof(CosmosProcessEventCache).Should().Implement<IProcessEventReader>();
+            typeof(CosmosProcessMessageCache).Should().Implement<IProcessEventReader>();
         }
 
         [TestMethod]
         public void sut_implements_IProcessEventCollector()
         {
-            typeof(CosmosProcessEventCache).Should().Implement<IProcessEventCollector>();
+            typeof(CosmosProcessMessageCache).Should().Implement<IProcessEventCollector>();
         }
 
         [TestMethod, AutoData]
@@ -78,7 +77,7 @@
             TypeResolver typeResolver)
         {
             // Arrange
-            var sut = new CosmosProcessEventCache(
+            var sut = new CosmosProcessMessageCache(
                 ConnectionString, DatabaseId, ContainerId, jsonProcessor, typeResolver);
 
             // Actt
@@ -118,7 +117,7 @@
             TypeResolver typeResolver)
         {
             // Arrange
-            var sut = new CosmosProcessEventCache(
+            var sut = new CosmosProcessMessageCache(
                 ConnectionString, DatabaseId, ContainerId, jsonProcessor, typeResolver);
             await sut.Collect(message, cancellationToken: CancellationToken.None);
 
@@ -139,7 +138,7 @@
             TypeResolver typeResolver)
         {
             // Arrange
-            var sut = new CosmosProcessEventCache(
+            var sut = new CosmosProcessMessageCache(
                 ConnectionString, DatabaseId, ContainerId, jsonProcessor, typeResolver);
 
             // Act


### PR DESCRIPTION
Rename CosmosProcessEventCache class to CosmosProcessMessageCache.

work items: [AB#50](https://dev.azure.com/tachycardia/f288cb04-fc97-4692-857f-b997e8543abb/_workitems/edit/50)