### PR TITLE
Rename IProcessEventReader interface

### DIFF
--- a/source/Loom.Messaging.Abstraction/Processes/IProcessMessageReader.cs
+++ b/source/Loom.Messaging.Abstraction/Processes/IProcessMessageReader.cs
@@ -4,7 +4,7 @@
     using System.Threading;
     using System.Threading.Tasks;
 
-    public interface IProcessEventReader
+    public interface IProcessMessageReader
     {
         Task<IEnumerable<Message>> Query(string operationId, CancellationToken cancellationToken);
     }

--- a/source/Loom.Messaging.Azure/Processes/Azure/CosmosProcessMessageCache.cs
+++ b/source/Loom.Messaging.Azure/Processes/Azure/CosmosProcessMessageCache.cs
@@ -14,7 +14,7 @@
     using Microsoft.Azure.Cosmos.Linq;
 
     public class CosmosProcessMessageCache
-        : IProcessEventReader, IProcessEventCollector
+        : IProcessMessageReader, IProcessEventCollector
     {
         private readonly Container _container;
         private readonly IJsonProcessor _jsonProcessor;

--- a/source/Loom.Tests/Messaging/Processes/Azure/CosmosProcessMessageCache_specs.cs
+++ b/source/Loom.Tests/Messaging/Processes/Azure/CosmosProcessMessageCache_specs.cs
@@ -59,9 +59,9 @@
         }
 
         [TestMethod]
-        public void sut_implements_IProcessEventReader()
+        public void sut_implements_IProcessMessageReader()
         {
-            typeof(CosmosProcessMessageCache).Should().Implement<IProcessEventReader>();
+            typeof(CosmosProcessMessageCache).Should().Implement<IProcessMessageReader>();
         }
 
         [TestMethod]


### PR DESCRIPTION
Rename IProcessEventReader interface to IProcessMessageReader.

work items: [AB#51](https://dev.azure.com/tachycardia/f288cb04-fc97-4692-857f-b997e8543abb/_workitems/edit/51)